### PR TITLE
updated error model

### DIFF
--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1,9 +1,9 @@
 {
   "swagger": "2.0",
   "info": {
-    "version": "0.2.21",
+    "version": "0.2.22",
     "title": "Vipps Invoice API",
-    "description": "# Welcome\nThis is the API for Vipps Regninger. While we have worked closely with selected partners, and believe that this is very close to production  quality, we are more than happy to receive feedback, either with GitHub's issue functionality, or by email.\n## ISP and IPP?\nThroughout this specification we use the terms ISP and IPP to categorize two groups of users.\n* ISP, the invoice service providers, are all actors who submit invoices.\n  Either for themselves or on behalf of their clients.\n* IPP, the invoice payment providers, are all actors who handle invoices\n  for the invoice recipients and execute payments, e.g. banks, the vipps\n  app.\n\nIn this test environment all endpoints are available for everyone. When we reach production a subset of the endpoints will be made available, based on the role you have assigned. ISP, IPP or both.\n# Core Functionality\n## Send, receive and pay invoices.\nSince version 0.1.8, we have changed the workflow. Previously, we followed the classical approach of working with batches. However, we wanted to simplify the workflow and be more explicit and have changed that approach in favour of a simple \\\"submit a single invoice\\\" approach. This means that invoices have to be posted one by one, each invoice in a separate http call.\nAlthough it might seem to be an \\\"inefficient\\\" approach, we believe that the benefits far outweight performance considerations. In addition, our tests have shown that the performance is well on par with a batch approach, if multiple threads are used to push invoices to our system.\nThe main benefits are that it becomes much easier to ensure and verify idempotency of the endpoint. We insert received invoices _synchronously_. In case of problems (5xx return codes or network issues), it is possible to just repeatedly submit invoices until a 2xx status code is returned. We guarantee that any invoice is exactly inserted once.\nThe validation of the invoice will still be an asynchronous process since we have no possibibility to guarantee or even estimate the response times for all required validation and risk checks we have to perform.\nTherefore, the invoice will be in a \\\"pending\\\" state once it is inserted. In this state the invoice will not be visible to anyone. First, when all validation steps are passed, the invoice will be shown to the recipients.\nISPs who provide the invoice will have to monitor the state. We provide two ways to do that.\n## Managing/Paying Invoices\nInvoice payment providers will mainly require to work with the resource `invoices` directly. The typical use case will be to fetch all invoices for a use/recipient, identified by his national identification number. This is provided by `GET: /invoices`.\nIf a user approves an invoice, the payment provider has to mark this individual invoice as processed so that the invoice is not displayed as an open invoice in other services.\n## Debt Collection\nAll invoices contain information about the _invoice type_, i.e. whether it is a regular invoice, reminder or other. This enables payment providers to filter the allowed payment methods according to Norwegian inkasso rules.\n## Retrieving invoice documents (i.e. commercial invoice and attachments)\nThe IPP should retrieve the *actual* document download URL on demand on behalf of its user. This is typically initiated when the user clicks on a download link in a UI. The user's request should first be made to a back-end system that in turn makes the authenticated request to this API to retrieve the *time-limited* URL to the actual document. The URL contains a *JWT* query parameter that is validated by the ISP. The expiry time (i.e. TTL) is inside the JWT.\nEach invoice document has one or more mime types. This means that `GET /invoices/{invoiceId}/attachments/{attachmentId}` must include the `mimeType` query parameter that specifies the mime type to retrieve, i.e. document file type. The mime type is available to the IPP when listing all the documents, so it is not necessary to guess.\n## Validating the JWT and the request\nThe IPP is responsible for validating the JWT. The JWT contains the following relevant claims:\n* `ISS` (issuer): Who is issuing the JWT. Typically `vipps-invoice-api`.\n* `AUD` (audience): Something identifying the IPP.\n* `SUB` (subject): The base URL for the document.\n* `EXP` (expiration): A specific moment in time where the JWT becomes invalid.\n* `ALG` (algorithm): Encryption algorithm. Vipps will use **RS256**.\n\nThe APIs public key is required in order to validate the request. The public key is available as JSON Web Key (JWK) under the `/jwk` endpoint. It is suggested to Use a JWK library to parse and use the key.\n\nIn addition to validating the JWT, the IPP/invoice hotel must ensure to validate the following:\n* The expired timestamp is in the future. I.e. not expired.\n* Make sure that the URL is valid. One approach is to return the `SUB` and ignore the actual path.\n\nFor details on JWT, use the [RFC](https://tools.ietf.org/html/rfc7519) or [jwt.io](https://www.jwt.io). The latter contains a list of pre-made libraries. We **highly** recommend using a pre-made library. It should at least validate the expiry time."
+    "description": "# Welcome\nThis is the API for Vipps Regninger. While we have worked closely with selected partners, and believe that this is very close to production quality, we are more than happy to receive feedback, either with GitHub's issue functionality, or by email.\n## ISP and IPP?\nThroughout this specification we use the terms ISP and IPP to categorize two groups of users.\n* ISP, the invoice service providers, are all actors who submit invoices.\n  Either for themselves or on behalf of their clients.\n* IPP, the invoice payment providers, are all actors who handle invoices\n  for the invoice recipients and execute payments, e.g. banks, the vipps\n  app.\n\nIn this test environment all endpoints are available for everyone. When we reach production a subset of the endpoints will be made available, based on the role you have assigned. ISP, IPP or both.\n# Core Functionality\n## Send, receive and pay invoices.\nSince version 0.1.8, we have changed the workflow. Previously, we followed the classical approach of working with batches. However, we wanted to simplify the workflow and be more explicit and have changed that approach in favour of a simple \\\"submit a single invoice\\\" approach. This means that invoices have to be posted one by one, each invoice in a separate http call.\nAlthough it might seem to be an \\\"inefficient\\\" approach, we believe that the benefits far outweight performance considerations. In addition, our tests have shown that the performance is well on par with a batch approach, if multiple threads are used to push invoices to our system.\nThe main benefits are that it becomes much easier to ensure and verify idempotency of the endpoint. We insert received invoices _synchronously_. In case of problems (5xx return codes or network issues), it is possible to just repeatedly submit invoices until a 2xx status code is returned. We guarantee that any invoice is exactly inserted once.\nThe validation of the invoice will still be an asynchronous process since we have no possibibility to guarantee or even estimate the response times for all required validation and risk checks we have to perform.\nTherefore, the invoice will be in a \\\"pending\\\" state once it is inserted. In this state the invoice will not be visible to anyone. First, when all validation steps are passed, the invoice will be shown to the recipients.\nISPs who provide the invoice will have to monitor the state. We provide two ways to do that.\n## Managing/Paying Invoices\nInvoice payment providers will mainly require to work with the resource `invoices` directly. The typical use case will be to fetch all invoices for a use/recipient, identified by his national identification number. This is provided by `GET: /invoices`.\nIf a user approves an invoice, the payment provider has to mark this individual invoice as processed so that the invoice is not displayed as an open invoice in other services.\n## Debt Collection\nAll invoices contain information about the _invoice type_, i.e. whether it is a regular invoice, reminder or other. This enables payment providers to filter the allowed payment methods according to Norwegian inkasso rules.\n## Retrieving invoice documents (i.e. commercial invoice and attachments)\nThe IPP should retrieve the *actual* document download URL on demand on behalf of its user. This is typically initiated when the user clicks on a download link in a UI. The user's request should first be made to a back-end system that in turn makes the authenticated request to this API to retrieve the *time-limited* URL to the actual document. The URL contains a *JWT* query parameter that is validated by the ISP. The expiry time (i.e. TTL) is inside the JWT.\nEach invoice document has one or more mime types. This means that `GET /invoices/{invoiceId}/attachments/{attachmentId}` must include the `mimeType` query parameter that specifies the mime type to retrieve, i.e. document file type. The mime type is available to the IPP when listing all the documents, so it is not necessary to guess.\n## Validating the JWT and the request\nThe IPP is responsible for validating the JWT. The JWT contains the following relevant claims:\n* `ISS` (issuer): Who is issuing the JWT. Typically `vipps-invoice-api`.\n* `AUD` (audience): Something identifying the IPP.\n* `SUB` (subject): The base URL for the document.\n* `EXP` (expiration): A specific moment in time where the JWT becomes invalid.\n* `ALG` (algorithm): Encryption algorithm. Vipps will use **RS256**.\n\nThe APIs public key is required in order to validate the request. The public key is available as JSON Web Key (JWK) under the `/jwk` endpoint. It is suggested to Use a JWK library to parse and use the key.\n\nIn addition to validating the JWT, the IPP/invoice hotel must ensure to validate the following:\n* The expired timestamp is in the future. I.e. not expired.\n* Make sure that the URL is valid. One approach is to return the `SUB` and ignore the actual path.\n\nFor details on JWT, use the [RFC](https://tools.ietf.org/html/rfc7519) or [jwt.io](https://www.jwt.io). The latter contains a list of pre-made libraries. We **highly** recommend using a pre-made library. It should at least validate the expiry time.\n# Changelog\n## New in 0.2.22\n* fix: the token returned from `GET:/recipients/tokens` is now returned\n  as a proper json document with the field `recipientToken`\n* extended the datamodel for errors. Error returned by the API will now\n  include the required fields `type` and `title` plus the optional fields\n  `detail` and `instance`. The content of the field is according to\n  [RFC7807](https://tools.ietf.org/html/rfc7807)"
   },
   "host": "invoice-mt.vippsbedrift.no",
   "basePath": "/v1",
@@ -49,7 +49,14 @@
           "200": {
             "description": "Recipient token",
             "schema": {
-              "type": "string"
+              "type": "object",
+              "properties": {
+                "recipientToken": {
+                  "type": "string",
+                  "description": "the recipient token",
+                  "example": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE1MzQ1MDMwMjMsImlhdCI6MTUzNDUwMjEyMywiaXNzIjoidmlwcHNpbnZvaWNlLnZpcHBzLm5vL2FwaS92MS9yZWNpcGllbnRzL3Rva2VucyIsIm5iZiI6MTUzNDUwMjEyMywic3ViIjoibmluLW5vLjA3MTI2MjAwMjU1In0.z0yJY8MXO4rDOGTA743fh4BOdnnCoVZLmdzi_goBipU"
+                }
+              }
             }
           },
           "400": {
@@ -1042,18 +1049,32 @@
         }
       }
     },
-    "Errors": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/Error"
-      }
-    },
     "Error": {
       "type": "object",
       "properties": {
         "error": {
-          "type": "string",
-          "example": "error message ..."
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "description": "A URI reference that identifies the problem type.",
+              "example": "https://vipps.no/invoice/v1/problems/invalid-invoice-id"
+            },
+            "title": {
+              "type": "string",
+              "description": "A short, human-readable summary of the problem type.",
+              "example": "The invoice id is invalid."
+            },
+            "detail": {
+              "type": "string",
+              "description": "A human-readable explanation specific to this occurrence of the problem.",
+              "example": "You tried to call the endpoint GET:/invoices/{invoiceId} with the invoice id **invoice-1**. This is invalid due to the following reasons: missing issuer ident-type, missing issuer ident-value."
+            },
+            "instance": {
+              "type": "string",
+              "description": "A URI reference that identifies the specific occurrence of the problem.  It may or may not yield further information if dereferenced."
+            }
+          }
         }
       }
     },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1,12 +1,12 @@
 swagger: '2.0'
 info:
-  version: 0.2.21
+  version: 0.2.22
   title: Vipps Invoice API
   description: >-
     # Welcome
 
     This is the API for Vipps Regninger. While we have worked closely with
-    selected partners, and believe that this is very close to production 
+    selected partners, and believe that this is very close to production
     quality, we are more than happy to receive feedback, either with
     GitHub's issue functionality, or by email.
 
@@ -123,6 +123,17 @@ info:
     We **highly** recommend using a pre-made library. It should at least validate the
     expiry time.
 
+    # Changelog
+
+    ## New in 0.2.22
+
+    * fix: the token returned from `GET:/recipients/tokens` is now returned
+      as a proper json document with the field `recipientToken`
+    * extended the datamodel for errors. Error returned by the API will now
+      include the required fields `type` and `title` plus the optional fields
+      `detail` and `instance`. The content of the field is according to
+      [RFC7807](https://tools.ietf.org/html/rfc7807)
+
 
 host: invoice-mt.vippsbedrift.no
 basePath: /v1
@@ -147,7 +158,7 @@ paths:
       description: >-
         Request a `recipientToken` by providing either the recipients Norwegian
         national identification or mobile number.
- 
+
         In the currently available test environment, two recipients are available:
 
         1. `nin-no`: 12068100117, `msisdn`: 4796147256
@@ -168,7 +179,12 @@ paths:
         '200':
           description: Recipient token
           schema:
-            type: string
+            type: object
+            properties:
+              recipientToken:
+                type: string
+                description: the recipient token
+                example: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE1MzQ1MDMwMjMsImlhdCI6MTUzNDUwMjEyMywiaXNzIjoidmlwcHNpbnZvaWNlLnZpcHBzLm5vL2FwaS92MS9yZWNpcGllbnRzL3Rva2VucyIsIm5iZiI6MTUzNDUwMjEyMywic3ViIjoibmluLW5vLjA3MTI2MjAwMjU1In0.z0yJY8MXO4rDOGTA743fh4BOdnnCoVZLmdzi_goBipU
         '400':
           description: Bad Request
           schema:
@@ -994,16 +1010,33 @@ definitions:
         description: >-
           Either the Norwegian national identification number or the mobile phone
           number.
-  Errors:
-    type: array
-    items:
-      $ref: '#/definitions/Error'
   Error:
     type: object
     properties:
       error:
-        type: string
-        example: error message ...
+        type: object
+        properties:
+          type:
+            type: string
+            description: A URI reference that identifies the problem type.
+            example: https://vipps.no/invoice/v1/problems/invalid-invoice-id
+          title:
+            type: string
+            description: A short, human-readable summary of the problem type.
+            example: The invoice id is invalid.
+          detail:
+            type: string
+            description: >-
+              A human-readable explanation specific to this occurrence of the problem.
+            example: >-
+              You tried to call the endpoint GET:/invoices/{invoiceId} with
+              the invoice id **invoice-1**. This is invalid due to the following
+              reasons: missing issuer ident-type, missing issuer ident-value.
+          instance:
+            type: string
+            description: >-
+              A URI reference that identifies the specific occurrence of the
+              problem.  It may or may not yield further information if dereferenced.
   JsonWebKeySet:
       title: "JSON Web Key Set"
       type: "object"


### PR DESCRIPTION
* fix: the token returned from `GET:/recipients/tokens` is now returned
      as a proper json document with the field `recipientToken`
* extended the datamodel for errors. Error returned by the API will now
      include the required fields `type` and `title` plus the optional fields
      `detail` and `instance`. The content of the field is according to
      [RFC7807](https://tools.ietf.org/html/rfc7807)