### PR TITLE
Added /jwk documentation

### DIFF
--- a/docs/swagger-ipp.json
+++ b/docs/swagger-ipp.json
@@ -2,8 +2,8 @@
   "swagger": "2.0",
   "info": {
     "title": "Vipps Invoice IPP API",
-    "version": "0.3.1",
-    "description": "This is the API for Vipps Regninger. While we have worked closely with selected partners, and believe that this is very close to production quality, we are more than happy to receive feedback, either with GitHub's issue functionality, or by email.\n# API documentation\nPlease see https://github.com/vippsas/vipps-invoice-api/blob/master/vipp-invoice-api.md\n# Invoice states\n* `created`: Invoice has been inserted, but not yet validated, and not yet shown to the recipient.\n* `rejected`: Invoice could not be validated, and is rejected.\n* `pending`: Invoice needs to be processed by the recipient.\n* `expired`: Recipient did not process the invoice in time.\n* `approved`: Invoice has been approved by recipient.\n* `deleted`: Invoice has been deleted.\n* `revoked`: Invoice has been revoked by the ISP.\nSee the `PUT:/invoices/{invoiceId}/status/{state}` methods for details about changing the `state`.\n\n# Changelog\n## 0.3.1\n* Text updates.\n## 0.3.0\n* Updated authentication info for APIM (manual \"merge\").\n## 0.2.28\n* Fix: Replaced `new` with `created`.\n## 0.2.26\n* Updated information about test users.\n## 0.2.25\n* Replaced introduction text with link to documentation.\n## 0.2.24\n* * Corrected documentation of `state` for invoices, and some minor text tweaks.\n## 0.2.23\n* Improved documentation for ìnvoiceId`.\n## 0.2.22\n* fix: the token returned from `GET:/recipients/tokens` is now returned\n  as a proper json document with the field `recipientToken`\n* extended the datamodel for errors. Error returned by the API will now\n  include the required fields `type` and `title` plus the optional fields\n  `detail` and `instance`. The content of the field is according to\n  [RFC7807](https://tools.ietf.org/html/rfc7807)"
+    "version": "0.3.2",
+    "description": "This is the API for Vipps Regninger. While we have worked closely with selected partners, and believe that this is very close to production quality, we are more than happy to receive feedback, either with GitHub's issue functionality, or by email.\n# API documentation\nPlease see https://github.com/vippsas/vipps-invoice-api/blob/master/vipp-invoice-api.md\n# Invoice states\n* `created`: Invoice has been inserted, but not yet validated, and not yet shown to the recipient.\n* `rejected`: Invoice could not be validated, and is rejected.\n* `pending`: Invoice needs to be processed by the recipient.\n* `expired`: Recipient did not process the invoice in time.\n* `approved`: Invoice has been approved by recipient.\n* `deleted`: Invoice has been deleted.\n* `revoked`: Invoice has been revoked by the ISP.\nSee the `PUT:/invoices/{invoiceId}/status/{state}` methods for details about changing the `state`.\n\n# Changelog\n## 0.3.2\n* Added `/jwk` (again).\n## 0.3.1\n* Text updates.\n## 0.3.0\n* Updated authentication info for APIM (manual \"merge\").\n## 0.2.28\n* Fix: Replaced `new` with `created`.\n## 0.2.26\n* Updated information about test users.\n## 0.2.25\n* Replaced introduction text with link to documentation.\n## 0.2.24\n* * Corrected documentation of `state` for invoices, and some minor text tweaks.\n## 0.2.23\n* Improved documentation for ìnvoiceId`.\n## 0.2.22\n* fix: the token returned from `GET:/recipients/tokens` is now returned\n  as a proper json document with the field `recipientToken`\n* extended the datamodel for errors. Error returned by the API will now\n  include the required fields `type` and `title` plus the optional fields\n  `detail` and `instance`. The content of the field is according to\n  [RFC7807](https://tools.ietf.org/html/rfc7807)"
   },
   "host": "apitest.vipps.no",
   "basePath": "/vipps-ipp/v1",
@@ -585,6 +585,39 @@
         "produces": [
           "application/json"
         ]
+      }
+    },
+    "/jwk": {
+      "get": {
+        "description": "Get JSON Web Key Set. Use a JWK library to parse this into a public key.",
+        "tags": [
+          "IPP"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "examples": {
+              "application/json": {
+                "keys": [
+                  {
+                    "e": "AQAB",
+                    "alg": "RS256",
+                    "use": "sig",
+                    "kid": "jwt",
+                    "kty": "RSA",
+                    "n": "5Dkax7lxzotIVx5DQidS..."
+                  }
+                ]
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/JsonWebKeySet"
+            }
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
       }
     }
   },

--- a/docs/swagger-ipp.yaml
+++ b/docs/swagger-ipp.yaml
@@ -1,7 +1,7 @@
 swagger: '2.0'
 info:
   title: Vipps Invoice IPP API
-  version: '0.3.1'
+  version: '0.3.2'
   description: >-
     This is the API for Vipps Regninger. While we have worked closely with
     selected partners, and believe that this is very close to production
@@ -32,6 +32,10 @@ info:
 
 
     # Changelog
+
+    ## 0.3.2
+
+    * Added `/jwk` (again).
 
     ## 0.3.1
 
@@ -484,6 +488,27 @@ paths:
           description: Server error. E.g. if JWT generation fails.
       produces:
         - application/json
+  /jwk:
+    get:
+      description: Get JSON Web Key Set. Use a JWK library to parse this into a public key.
+      tags:
+        - IPP
+      responses:
+        '200':
+          description: OK
+          examples:
+            application/json:
+              keys:
+                - e: AQAB
+                  alg: RS256
+                  use: sig
+                  kid: jwt
+                  kty: RSA
+                  'n': 5Dkax7lxzotIVx5DQidS...
+          schema:
+            $ref: '#/definitions/JsonWebKeySet'
+        '500':
+          description: Internal server error
 definitions:
   recipientToken:
     type: object

--- a/docs/swagger-isp.json
+++ b/docs/swagger-isp.json
@@ -2,8 +2,8 @@
   "swagger": "2.0",
   "info": {
     "title": "Vipps Invoice ISP API",
-    "version": "0.3.0",
-    "description": "\nThis is the API for Vipps Regninger. While we have worked closely with selected partners, and believe that this is very close to production quality, we are more than happy to receive feedback, either with GitHub's issue functionality, or by email.\n# API documentation\nPlease see https://github.com/vippsas/vipps-invoice-api/blob/master/vipps-invoice-api.md\n# Invoice states\n* `created`: Invoice has been inserted, but not yet validated, and not yet shown to the recipient.\n* `rejected`: Invoice could not be validated, and is rejected.\n* `pending`: Invoice needs to be processed by the recipient.\n* `expired`: Recipient did not process the invoice in time.\n* `approved`: Invoice has been approved by recipient.\n* `deleted`: Invoice has been deleted.\n* `revoked`: Invoice has been revoked by the ISP.\nSee the `PUT:/invoices/{invoiceId}/status/{state}` methods for details about changing the `state`.\n\n# Changelog\n## 0.3.0\n* * Updated authentication info for APIM (manual \"merge\").\n## 0.2.28\n* Fix: Replaced `new` with `created`, also for endpoints not implemented yet.\n## 0.2.27\n* Fix: Replaced `new` with `created`.\n## 0.2.26\n* Updated information about test users.\n## 0.2.25\n* Replaced introduction text with link to documentation.\n## 0.2.24\n* * Corrected documentation of `state` for invoices, and some minor text tweaks.\n## 0.2.23\n* Improved documentation for ìnvoiceId`.\n## 0.2.22\n* fix: the token returned from `GET:/recipients/tokens` is now returned\n  as a proper json document with the field `recipientToken`\n* extended the datamodel for errors. Error returned by the API will now\n  include the required fields `type` and `title` plus the optional fields\n  `detail` and `instance`. The content of the field is according to\n  [RFC7807](https://tools.ietf.org/html/rfc7807)"
+    "version": "0.3.1",
+    "description": "\nThis is the API for Vipps Regninger. While we have worked closely with selected partners, and believe that this is very close to production quality, we are more than happy to receive feedback, either with GitHub's issue functionality, or by email.\n# API documentation\nPlease see https://github.com/vippsas/vipps-invoice-api/blob/master/vipps-invoice-api.md\n# Invoice states\n* `created`: Invoice has been inserted, but not yet validated, and not yet shown to the recipient.\n* `rejected`: Invoice could not be validated, and is rejected.\n* `pending`: Invoice needs to be processed by the recipient.\n* `expired`: Recipient did not process the invoice in time.\n* `approved`: Invoice has been approved by recipient.\n* `deleted`: Invoice has been deleted.\n* `revoked`: Invoice has been revoked by the ISP.\nSee the `PUT:/invoices/{invoiceId}/status/{state}` methods for details about changing the `state`.\n\n# Changelog\n## 0.3.1\n* Added `/jwk` (again).\n## 0.3.0\n* * Updated authentication info for APIM (manual \"merge\").\n## 0.2.28\n* Fix: Replaced `new` with `created`, also for endpoints not implemented yet.\n## 0.2.27\n* Fix: Replaced `new` with `created`.\n## 0.2.26\n* Updated information about test users.\n## 0.2.25\n* Replaced introduction text with link to documentation.\n## 0.2.24\n* * Corrected documentation of `state` for invoices, and some minor text tweaks.\n## 0.2.23\n* Improved documentation for ìnvoiceId`.\n## 0.2.22\n* fix: the token returned from `GET:/recipients/tokens` is now returned\n  as a proper json document with the field `recipientToken`\n* extended the datamodel for errors. Error returned by the API will now\n  include the required fields `type` and `title` plus the optional fields\n  `detail` and `instance`. The content of the field is according to\n  [RFC7807](https://tools.ietf.org/html/rfc7807)"
   },
   "host": "apitest.vipps.no",
   "basePath": "/vipps-isp/v1",
@@ -257,6 +257,39 @@
         "produces": [
           "application/json"
         ]
+      }
+    },
+    "/jwk": {
+      "get": {
+        "description": "Get JSON Web Key Set. Use a JWK library to parse this into a public key.",
+        "tags": [
+          "ISP"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "examples": {
+              "application/json": {
+                "keys": [
+                  {
+                    "e": "AQAB",
+                    "alg": "RS256",
+                    "use": "sig",
+                    "kid": "jwt",
+                    "kty": "RSA",
+                    "n": "5Dkax7lxzotIVx5DQidS..."
+                  }
+                ]
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/JsonWebKeySet"
+            }
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
       }
     }
   },

--- a/docs/swagger-isp.yaml
+++ b/docs/swagger-isp.yaml
@@ -1,7 +1,7 @@
 swagger: '2.0'
 info:
   title: Vipps Invoice ISP API
-  version: '0.3.0'
+  version: '0.3.1'
   description: >-
 
     This is the API for Vipps Regninger. While we have worked closely with
@@ -33,6 +33,10 @@ info:
 
 
     # Changelog
+
+    ## 0.3.1
+
+    * Added `/jwk` (again).
 
     ## 0.3.0
 
@@ -284,6 +288,27 @@ paths:
           description: Invoice not found
       produces:
         - application/json
+  /jwk:
+    get:
+      description: Get JSON Web Key Set. Use a JWK library to parse this into a public key.
+      tags:
+        - ISP
+      responses:
+        '200':
+          description: OK
+          examples:
+            application/json:
+              keys:
+                - e: AQAB
+                  alg: RS256
+                  use: sig
+                  kid: jwt
+                  kty: RSA
+                  'n': 5Dkax7lxzotIVx5DQidS...
+          schema:
+            $ref: '#/definitions/JsonWebKeySet'
+        '500':
+          description: Internal server error
 definitions:
   recipientToken:
     type: object


### PR DESCRIPTION
Added `/jwk`documentation that was accidentally removed in an earlier update. The authentication for `/jwk`will be removed in APIM on the morning of August 30, *but we are updating the Swagger now*.