### PR TITLE
Remove URL from InvoiceOut.CommercialInvoice

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ install it using `pip`.
 
 # Swagger changelog
 
+## 0.3.8
+
+* Removed URL to commercial invoice in invoiceOut.
+
 ## 0.3.7
 
 * Corrected `state` for invoices in Swagger. 

--- a/docs/swagger-ipp.json
+++ b/docs/swagger-ipp.json
@@ -964,11 +964,6 @@
                 "type": "string",
                 "description": "MIME type of commercial invoice document",
                 "example": "application/pdf"
-              },
-              "url": {
-                "type": "string",
-                "description": "URL of the commercial invoice provided by the IPP. Not meant for direct use the specialized endpoint for retrieving a URL with a token.",
-                "example": "https://invoice-hotel.example.org/123456-abcdef-7890.pdf"
               }
             }
           }

--- a/docs/swagger-ipp.json
+++ b/docs/swagger-ipp.json
@@ -2,7 +2,7 @@
   "swagger": "2.0",
   "info": {
     "title": "Vipps Invoice IPP API",
-    "version": "0.3.7",
+    "version": "0.3.8",
     "description": "This is the API for Vipps Regninger. While we have worked closely with selected partners, and believe that this is very close to production quality, we are more than happy to receive feedback, either with GitHub's issue functionality, or by email.\nPlease see https://github.com/vippsas/vipps-invoice-api for documentation"
   },
   "host": "apitest.vipps.no",

--- a/docs/swagger-ipp.yaml
+++ b/docs/swagger-ipp.yaml
@@ -706,10 +706,6 @@ definitions:
               type: string
               description: MIME type of commercial invoice document
               example: application/pdf
-            url:
-              type: string
-              description: URL of the commercial invoice provided by the IPP. Not meant for direct use the specialized endpoint for retrieving a URL with a token.
-              example: 'https://invoice-hotel.example.org/123456-abcdef-7890.pdf'
       attachments:
         type: array
         description: Invoice attachments

--- a/docs/swagger-ipp.yaml
+++ b/docs/swagger-ipp.yaml
@@ -1,7 +1,7 @@
 swagger: '2.0'
 info:
   title: Vipps Invoice IPP API
-  version: '0.3.7'
+  version: '0.3.8'
   description: >-
     This is the API for Vipps Regninger. While we have worked closely with
     selected partners, and believe that this is very close to production

--- a/docs/swagger-isp.json
+++ b/docs/swagger-isp.json
@@ -623,11 +623,6 @@
                 "type": "string",
                 "description": "MIME type of commercial invoice document",
                 "example": "application/pdf"
-              },
-              "url": {
-                "type": "string",
-                "description": "URL of the commercial invoice provided by the IPP. Not meant for direct use the specialized endpoint for retrieving a URL with a token.",
-                "example": "https://invoice-hotel.example.org/123456-abcdef-7890.pdf"
               }
             }
           }

--- a/docs/swagger-isp.json
+++ b/docs/swagger-isp.json
@@ -2,7 +2,7 @@
   "swagger": "2.0",
   "info": {
     "title": "Vipps Invoice ISP API",
-    "version": "0.3.7",
+    "version": "0.3.8",
     "description": "\nThis is the API for Vipps Regninger. While we have worked closely with selected partners, and believe that this is very close to production quality, we are more than happy to receive feedback, either with GitHub's issue functionality, or by email.\nPlease see https://github.com/vippsas/vipps-invoice-api for documentation"
   },
   "host": "apitest.vipps.no",

--- a/docs/swagger-isp.yaml
+++ b/docs/swagger-isp.yaml
@@ -522,13 +522,6 @@ definitions:
               type: string
               description: MIME type of commercial invoice document
               example: application/pdf
-            url:
-              type: string
-              description: >-
-                URL of the commercial invoice provided by the IPP. Not meant for
-                direct use the specialized endpoint for retrieving a URL with a
-                token.
-              example: 'https://invoice-hotel.example.org/123456-abcdef-7890.pdf'
       attachments:
         type: array
         description: Invoice attachments.

--- a/docs/swagger-isp.yaml
+++ b/docs/swagger-isp.yaml
@@ -1,7 +1,7 @@
 swagger: '2.0'
 info:
   title: Vipps Invoice ISP API
-  version: '0.3.7'
+  version: '0.3.8'
   description: >-
 
     This is the API for Vipps Regninger. While we have worked closely with


### PR DESCRIPTION
The tokenized URL for a commercial invoice must be retrieved from the dedicated endpoint and the url in InvoiceOut.commercialInvoice is superfluous.