### PR TITLE
ISP: Remove recipient token from GetInvoiceByID

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ install it using `pip`.
 
 # Swagger changelog
 
+## 0.3.17
+
+* ISP: Remove requirement for recipient token on GetInvoiceByID
+
 ## 0.3.16
 
 * Add info about logo requirements

--- a/docs/swagger-ipp.json
+++ b/docs/swagger-ipp.json
@@ -2,7 +2,7 @@
   "swagger": "2.0",
   "info": {
     "title": "Vipps Invoice IPP API",
-    "version": "0.3.16",
+    "version": "0.3.17",
     "description": "This is the API for Vipps Regninger. While we have worked closely with selected partners, and believe that this is very close to production quality, we are more than happy to receive feedback, either with GitHub's issue functionality, or by email.\nPlease see https://github.com/vippsas/vipps-invoice-api for documentation"
   },
   "host": "apitest.vipps.no",

--- a/docs/swagger-ipp.yaml
+++ b/docs/swagger-ipp.yaml
@@ -1,7 +1,7 @@
 swagger: '2.0'
 info:
   title: Vipps Invoice IPP API
-  version: '0.3.16'
+  version: '0.3.17'
   description: >-
     This is the API for Vipps Regninger. While we have worked closely with
     selected partners, and believe that this is very close to production

--- a/docs/swagger-isp.json
+++ b/docs/swagger-isp.json
@@ -2,7 +2,7 @@
   "swagger": "2.0",
   "info": {
     "title": "Vipps Invoice ISP API",
-    "version": "0.3.16",
+    "version": "0.3.17",
     "description": "\nThis is the API for Vipps Regninger. While we have worked closely with selected partners, and believe that this is very close to production quality, we are more than happy to receive feedback, either with GitHub's issue functionality, or by email.\nPlease see https://github.com/vippsas/vipps-invoice-api for documentation"
   },
   "host": "apitest.vipps.no",
@@ -193,13 +193,6 @@
             "name": "invoiceId",
             "in": "path",
             "description": "The unique invoice id.",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "vippsinvoice-recipienttoken",
-            "in": "header",
-            "description": "Recipient token. Issued by vipps.",
             "required": true,
             "type": "string"
           },

--- a/docs/swagger-isp.yaml
+++ b/docs/swagger-isp.yaml
@@ -1,7 +1,7 @@
 swagger: '2.0'
 info:
   title: Vipps Invoice ISP API
-  version: '0.3.16'
+  version: '0.3.17'
   description: >-
 
     This is the API for Vipps Regninger. While we have worked closely with
@@ -161,11 +161,6 @@ paths:
         - name: invoiceId
           in: path
           description: The unique invoice id.
-          required: true
-          type: string
-        - name: vippsinvoice-recipienttoken
-          in: header
-          description: Recipient token. Issued by vipps.
           required: true
           type: string
         - name: Authorization


### PR DESCRIPTION
ISP does not need a recipient token to fetch a single invoice by ID.