### PR TITLE
Updated documentation regarding deprecation of attachments

### DIFF
--- a/docs/swagger-ipp.json
+++ b/docs/swagger-ipp.json
@@ -634,7 +634,7 @@
       "get": {
         "description": "Returns a time-limited URL to a single attachment for an invoice. This URL typically points to a third-party invoice hotel that hosts the document. The third-party is responsible for validating the JWT.",
         "operationId": "Get_Attachment_For_Invoice_v1",
-        "summary": "Get attachment for invoice",
+        "summary": "Deprecated",
         "tags": [
           "IPP"
         ],
@@ -812,42 +812,6 @@
         }
       }
     },
-    "attachmentUrlOut": {
-      "description": "Generated URL for attachment",
-      "type": "object",
-      "properties": {
-        "url": {
-          "type": "string",
-          "example": "https://invoice-hotel.example.org/123456-abcdef-7890.pdf?token=eyJh.TY3ODk.SflKxw_adQssw5c"
-        }
-      }
-    },
-    "attachmentOut": {
-      "description": "A list of optional attachments related to an invoice",
-      "type": "object",
-      "required": [
-        "id",
-        "title",
-        "mimeTypes"
-      ],
-      "properties": {
-        "id": {
-          "type": "string",
-          "example": "1"
-        },
-        "title": {
-          "type": "string",
-          "example": "Ferry"
-        },
-        "mimeTypes": {
-          "type": "array",
-          "items": {
-            "type": "string",
-            "example": "application/pdf"
-          }
-        }
-      }
-    },
     "invoiceOut": {
       "description": "Invoice document which is returned from our servers. The `invoiceId` consists of the prefix `orgno-no` (for all Norwegian organizations), the actual organization number and the reference number for this invoice.",
       "type": "object",
@@ -972,13 +936,6 @@
                 "example": "application/pdf"
               }
             }
-          }
-        },
-        "attachments": {
-          "type": "array",
-          "description": "Invoice attachments",
-          "items": {
-            "$ref": "#/definitions/attachmentOut"
           }
         },
         "issuerIconUrl": {

--- a/docs/swagger-ipp.json
+++ b/docs/swagger-ipp.json
@@ -634,7 +634,7 @@
       "get": {
         "description": "Returns a time-limited URL to a single attachment for an invoice. This URL typically points to a third-party invoice hotel that hosts the document. The third-party is responsible for validating the JWT.",
         "operationId": "Get_Attachment_For_Invoice_v1",
-        "summary": "Deprecated",
+        "summary": "DEPRECATED Get attachment for invoice",
         "tags": [
           "IPP"
         ],
@@ -812,6 +812,42 @@
         }
       }
     },
+    "attachmentUrlOut": {
+      "description": "DEPRECATED Generated URL for attachment",
+      "type": "object",
+      "properties": {
+        "url": {
+          "type": "string",
+          "example": "https://invoice-hotel.example.org/123456-abcdef-7890.pdf?token=eyJh.TY3ODk.SflKxw_adQssw5c"
+        }
+      }
+    },
+    "attachmentOut": {
+      "description": "DEPRECATED A list of optional attachments related to an invoice",
+      "type": "object",
+      "required": [
+        "id",
+        "title",
+        "mimeTypes"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "example": "1"
+        },
+        "title": {
+          "type": "string",
+          "example": "Ferry"
+        },
+        "mimeTypes": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "example": "application/pdf"
+          }
+        }
+      }
+    },
     "invoiceOut": {
       "description": "Invoice document which is returned from our servers. The `invoiceId` consists of the prefix `orgno-no` (for all Norwegian organizations), the actual organization number and the reference number for this invoice.",
       "type": "object",
@@ -936,6 +972,13 @@
                 "example": "application/pdf"
               }
             }
+          }
+        },
+        "attachments": {
+          "type": "array",
+          "description": "Invoice attachments",
+          "items": {
+            "$ref": "#/definitions/attachmentOut"
           }
         },
         "issuerIconUrl": {

--- a/docs/swagger-ipp.yaml
+++ b/docs/swagger-ipp.yaml
@@ -460,7 +460,7 @@ paths:
     get:
       description: Returns a time-limited URL to a single attachment for an invoice. This URL typically points to a third-party invoice hotel that hosts the document. The third-party is responsible for validating the JWT.
       operationId: Get_Attachment_For_Invoice_v1
-      summary: Deprecated 
+      summary: DEPRECATED Get attachment for invoice
       tags:
         - IPP
       parameters:
@@ -579,6 +579,32 @@ definitions:
       url:
         type: string
         example: 'https://invoice-hotel.example.org/123456-abcdef-7890.pdf?token=eyJh.TY3ODk.SflKxw_adQssw5c'
+  attachmentUrlOut:
+    description: DEPRECATED Generated URL for attachment
+    type: object
+    properties:
+      url:
+        type: string
+        example: 'https://invoice-hotel.example.org/123456-abcdef-7890.pdf?token=eyJh.TY3ODk.SflKxw_adQssw5c'
+  attachmentOut:
+    description: DEPRECATED A list of optional attachments related to an invoice
+    type: object
+    required:
+      - id
+      - title
+      - mimeTypes
+    properties:
+      id:
+        type: string
+        example: "1"
+      title:
+        type: string
+        example: Ferry
+      mimeTypes:
+        type: array
+        items:
+          type: string
+          example: application/pdf
   invoiceOut:
     description: 'Invoice document which is returned from our servers. The `invoiceId` consists of the prefix `orgno-no` (for all Norwegian organizations), the actual organization number and the reference number for this invoice.'
     type: object
@@ -680,6 +706,11 @@ definitions:
               type: string
               description: MIME type of commercial invoice document. Supported MIME types - application/pdf (recommended), image/png, image/jpeg, image/jpg, text/html, text/plain
               example: application/pdf
+      attachments:
+        type: array
+        description: Invoice attachments
+        items:
+          $ref: '#/definitions/attachmentOut'
       issuerIconUrl:
         type: string
         description: URL to invoice issuer's logo

--- a/docs/swagger-ipp.yaml
+++ b/docs/swagger-ipp.yaml
@@ -460,7 +460,7 @@ paths:
     get:
       description: Returns a time-limited URL to a single attachment for an invoice. This URL typically points to a third-party invoice hotel that hosts the document. The third-party is responsible for validating the JWT.
       operationId: Get_Attachment_For_Invoice_v1
-      summary: Get attachment for invoice
+      summary: Deprecated 
       tags:
         - IPP
       parameters:
@@ -579,32 +579,6 @@ definitions:
       url:
         type: string
         example: 'https://invoice-hotel.example.org/123456-abcdef-7890.pdf?token=eyJh.TY3ODk.SflKxw_adQssw5c'
-  attachmentUrlOut:
-    description: Generated URL for attachment
-    type: object
-    properties:
-      url:
-        type: string
-        example: 'https://invoice-hotel.example.org/123456-abcdef-7890.pdf?token=eyJh.TY3ODk.SflKxw_adQssw5c'
-  attachmentOut:
-    description: A list of optional attachments related to an invoice
-    type: object
-    required:
-      - id
-      - title
-      - mimeTypes
-    properties:
-      id:
-        type: string
-        example: "1"
-      title:
-        type: string
-        example: Ferry
-      mimeTypes:
-        type: array
-        items:
-          type: string
-          example: application/pdf
   invoiceOut:
     description: 'Invoice document which is returned from our servers. The `invoiceId` consists of the prefix `orgno-no` (for all Norwegian organizations), the actual organization number and the reference number for this invoice.'
     type: object
@@ -706,11 +680,6 @@ definitions:
               type: string
               description: MIME type of commercial invoice document. Supported MIME types - application/pdf (recommended), image/png, image/jpeg, image/jpg, text/html, text/plain
               example: application/pdf
-      attachments:
-        type: array
-        description: Invoice attachments
-        items:
-          $ref: '#/definitions/attachmentOut'
       issuerIconUrl:
         type: string
         description: URL to invoice issuer's logo

--- a/docs/swagger-isp.json
+++ b/docs/swagger-isp.json
@@ -709,79 +709,10 @@
             }
           }
         },
-        "attachments": {
-          "type": "array",
-          "description": "Invoice attachments.",
-          "items": {
-            "$ref": "#/definitions/attachmentIn"
-          }
-        },
         "issuerIconUrl": {
           "type": "string",
           "description": "URL to invoice issuer's logo. The URL must use the https-protocol and not contain any tracking-scripts or user-tracking parameters. Supported image formats: SVG (Scalable Vector Graphics) and PNG (Portable Network Graphics). Minimum size: 82x82 pixels Maximum size: 512x512 pixels",
           "example": "https://www.example.com/logos/lister.png"
-        }
-      }
-    },
-    "attachmentIn": {
-      "description": "An incoming attachment related to an invoice",
-      "type": "object",
-      "required": [
-        "title",
-        "urls"
-      ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "example": "Ferry"
-        },
-        "urls": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "required": [
-              "url",
-              "mimeType"
-            ],
-            "properties": {
-              "url": {
-                "description": "An URL to the attachment. It is required to use the HTTPS-protocol.",
-                "type": "string",
-                "example": "https://invoice-hotel.example.org/invoice/42.pdf"
-              },
-              "mimeType": {
-                "description": "Mime-type of the attachment document. Supported mime-types are; application/pdf (recommended), image/png, image/jpeg, image/jpg, text/html, text/plain",
-                "type": "string",
-                "example": "application/pdf"
-              }
-            }
-          }
-        }
-      }
-    },
-    "attachmentOut": {
-      "description": "A list of optional attachments related to an invoice",
-      "type": "object",
-      "required": [
-        "id",
-        "title",
-        "mimeTypes"
-      ],
-      "properties": {
-        "id": {
-          "type": "string",
-          "example": "1"
-        },
-        "title": {
-          "type": "string",
-          "example": "Ferry"
-        },
-        "mimeTypes": {
-          "type": "array",
-          "items": {
-            "type": "string",
-            "example": "application/pdf"
-          }
         }
       }
     },
@@ -947,13 +878,6 @@
                 "example": "application/pdf"
               }
             }
-          }
-        },
-        "attachments": {
-          "type": "array",
-          "description": "Invoice attachments",
-          "items": {
-            "$ref": "#/definitions/attachmentOut"
           }
         },
         "issuerIconUrl": {

--- a/docs/swagger-isp.json
+++ b/docs/swagger-isp.json
@@ -709,10 +709,79 @@
             }
           }
         },
+        "attachments": {
+          "type": "array",
+          "description": "DEPRECATED Invoice attachments.",
+          "items": {
+            "$ref": "#/definitions/attachmentIn"
+          }
+        },
         "issuerIconUrl": {
           "type": "string",
           "description": "URL to invoice issuer's logo. The URL must use the https-protocol and not contain any tracking-scripts or user-tracking parameters. Supported image formats: SVG (Scalable Vector Graphics) and PNG (Portable Network Graphics). Minimum size: 82x82 pixels Maximum size: 512x512 pixels",
           "example": "https://www.example.com/logos/lister.png"
+        }
+      }
+    },
+    "attachmentIn": {
+      "description": "DEPRECATED An incoming attachment related to an invoice",
+      "type": "object",
+      "required": [
+        "title",
+        "urls"
+      ],
+      "properties": {
+        "title": {
+          "type": "string",
+          "example": "Ferry"
+        },
+        "urls": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "url",
+              "mimeType"
+            ],
+            "properties": {
+              "url": {
+                "description": "An URL to the attachment. It is required to use the HTTPS-protocol.",
+                "type": "string",
+                "example": "https://invoice-hotel.example.org/invoice/42.pdf"
+              },
+              "mimeType": {
+                "description": "Mime-type of the attachment document. Supported mime-types are; application/pdf (recommended), image/png, image/jpeg, image/jpg, text/html, text/plain",
+                "type": "string",
+                "example": "application/pdf"
+              }
+            }
+          }
+        }
+      }
+    },
+    "attachmentOut": {
+      "description": "DEPRECATED A list of optional attachments related to an invoice",
+      "type": "object",
+      "required": [
+        "id",
+        "title",
+        "mimeTypes"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "example": "1"
+        },
+        "title": {
+          "type": "string",
+          "example": "Ferry"
+        },
+        "mimeTypes": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "example": "application/pdf"
+          }
         }
       }
     },
@@ -878,6 +947,13 @@
                 "example": "application/pdf"
               }
             }
+          }
+        },
+        "attachments": {
+          "type": "array",
+          "description": "DEPRECATED Invoice attachments",
+          "items": {
+            "$ref": "#/definitions/attachmentOut"
           }
         },
         "issuerIconUrl": {

--- a/docs/swagger-isp.yaml
+++ b/docs/swagger-isp.yaml
@@ -566,6 +566,11 @@ definitions:
               description: URL of commercial invoice. It is required to use the https-protocol.
               example: >-
                 https://www.example.com/08fd5360-e218-4658-894f-4f37649e7df7/comminv.pdf
+      attachments:
+        type: array
+        description: DEPRECATED Invoice attachments.
+        items:
+          $ref: '#/definitions/attachmentIn'
       issuerIconUrl:
         type: string
         description: >-
@@ -574,6 +579,53 @@ definitions:
           Minimum size: 82x82 pixels
           Maximum size: 512x512 pixels
         example: 'https://www.example.com/logos/lister.png'
+  attachmentIn:
+    description: DEPRECATED An incoming attachment related to an invoice
+    type: object
+    required:
+      - title
+      - urls
+    properties:
+      title:
+        type: string
+        example: Ferry
+      urls:
+        type: array
+        items:
+          type: object
+          required:
+            - url
+            - mimeType
+          properties:
+            url:
+              description: An URL to the attachment. It is required to use the HTTPS-protocol.
+              type: string
+              example: 'https://invoice-hotel.example.org/invoice/42.pdf'
+            mimeType:
+              description: >-
+                Mime-type of the attachment document.
+                Supported mime-types are; application/pdf (recommended), image/png, image/jpeg, image/jpg, text/html, text/plain
+              type: string
+              example: application/pdf
+  attachmentOut:
+    description: DEPRECATED A list of optional attachments related to an invoice
+    type: object
+    required:
+      - id
+      - title
+      - mimeTypes
+    properties:
+      id:
+        type: string
+        example: "1"
+      title:
+        type: string
+        example: Ferry
+      mimeTypes:
+        type: array
+        items:
+          type: string
+          example: application/pdf
   InvoiceStatusResponse:
     description: >-
       Response from querying for multiple invoice statuses.
@@ -719,6 +771,11 @@ definitions:
               type: string
               description: Mime-type of commercial invoice document
               example: application/pdf
+      attachments:
+        type: array
+        description: DEPRECATED Invoice attachments
+        items:
+          $ref: '#/definitions/attachmentOut'
       issuerIconUrl:
         type: string
         description: URL to invoice issuer's logo

--- a/docs/swagger-isp.yaml
+++ b/docs/swagger-isp.yaml
@@ -566,11 +566,6 @@ definitions:
               description: URL of commercial invoice. It is required to use the https-protocol.
               example: >-
                 https://www.example.com/08fd5360-e218-4658-894f-4f37649e7df7/comminv.pdf
-      attachments:
-        type: array
-        description: Invoice attachments.
-        items:
-          $ref: '#/definitions/attachmentIn'
       issuerIconUrl:
         type: string
         description: >-
@@ -579,53 +574,6 @@ definitions:
           Minimum size: 82x82 pixels
           Maximum size: 512x512 pixels
         example: 'https://www.example.com/logos/lister.png'
-  attachmentIn:
-    description: An incoming attachment related to an invoice
-    type: object
-    required:
-      - title
-      - urls
-    properties:
-      title:
-        type: string
-        example: Ferry
-      urls:
-        type: array
-        items:
-          type: object
-          required:
-            - url
-            - mimeType
-          properties:
-            url:
-              description: An URL to the attachment. It is required to use the HTTPS-protocol.
-              type: string
-              example: 'https://invoice-hotel.example.org/invoice/42.pdf'
-            mimeType:
-              description: >-
-                Mime-type of the attachment document.
-                Supported mime-types are; application/pdf (recommended), image/png, image/jpeg, image/jpg, text/html, text/plain
-              type: string
-              example: application/pdf
-  attachmentOut:
-    description: A list of optional attachments related to an invoice
-    type: object
-    required:
-      - id
-      - title
-      - mimeTypes
-    properties:
-      id:
-        type: string
-        example: "1"
-      title:
-        type: string
-        example: Ferry
-      mimeTypes:
-        type: array
-        items:
-          type: string
-          example: application/pdf
   InvoiceStatusResponse:
     description: >-
       Response from querying for multiple invoice statuses.
@@ -771,11 +719,6 @@ definitions:
               type: string
               description: Mime-type of commercial invoice document
               example: application/pdf
-      attachments:
-        type: array
-        description: Invoice attachments
-        items:
-          $ref: '#/definitions/attachmentOut'
       issuerIconUrl:
         type: string
         description: URL to invoice issuer's logo

--- a/tools/vipps-invoice-ipp-api-postman-collection.json
+++ b/tools/vipps-invoice-ipp-api-postman-collection.json
@@ -1,8 +1,8 @@
 {
 	"info": {
-		"_postman_id": "3852d627-4075-4c08-bab7-bb2b9bde7450",
-		"name": "Vipps Invoice IPP MT",
-		"description": "This is the API for Vipps Regninger. While we have worked closely with selected partners, we are more than happy to receive feedback, either with GitHub's issue functionality, or by email.\nPlease see https://github.com/vippsas/vipps-invoice-api for documentation",
+		"_postman_id": "a2106663-0faf-4411-92f4-599c6d6aba94",
+		"name": "Vipps Invoice IPP Prod Copy",
+		"description": "This is the API for Vipps Regninger. While we have worked closely with selected partners, and believe that this is very close to production quality, we are more than happy to receive feedback, either with GitHub's issue functionality, or by email.\nPlease see https://github.com/vippsas/vipps-invoice-api for documentation",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
 	"item": [
@@ -52,10 +52,10 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "https://apitest.vipps.no/accesstoken/get",
+							"raw": "https://api.vipps.no/accesstoken/get",
 							"protocol": "https",
 							"host": [
-								"apitest",
+								"api",
 								"vipps",
 								"no"
 							],
@@ -110,12 +110,12 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n  \"type\": \"nin-no\",\n  \"value\": \"<nin>\"\n}"
+							"raw": "{\n  \"type\": \"nin-no\",\n  \"value\": \"10059048312\"\n}"
 						},
 						"url": {
-							"raw": "{{TEST-URL}}recipients/tokens",
+							"raw": "{{URL}}recipients/tokens",
 							"host": [
-								"{{TEST-URL}}recipients"
+								"{{URL}}recipients"
 							],
 							"path": [
 								"tokens"
@@ -161,12 +161,12 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n  \"type\": \"msisdn\",\n  \"value\": \"<msisdn>\"\n}"
+							"raw": "{\n  \"type\": \"msisdn\",\n  \"value\": \"4792496079\"\n}"
 						},
 						"url": {
-							"raw": "{{TEST-URL}}recipients/tokens",
+							"raw": "{{URL}}recipients/tokens",
 							"host": [
-								"{{TEST-URL}}recipients"
+								"{{URL}}recipients"
 							],
 							"path": [
 								"tokens"
@@ -221,14 +221,14 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "{{TEST-URL}}invoices?state=approved",
+							"raw": "{{URL}}invoices?status=all",
 							"host": [
-								"{{TEST-URL}}invoices"
+								"{{URL}}invoices"
 							],
 							"query": [
 								{
-									"key": "state",
-									"value": "approved"
+									"key": "status",
+									"value": "all"
 								}
 							]
 						},
@@ -263,17 +263,17 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "{{TEST-URL}}invoices/count?state=pending",
+							"raw": "{{URL}}invoices/count?status=all",
 							"host": [
-								"{{TEST-URL}}invoices"
+								"{{URL}}invoices"
 							],
 							"path": [
 								"count"
 							],
 							"query": [
 								{
-									"key": "state",
-									"value": "pending"
+									"key": "status",
+									"value": "all"
 								}
 							]
 						},
@@ -330,12 +330,12 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "{{TEST-URL}}invoices/<invoiceID>",
+							"raw": "{{URL}}invoices/orgno-no.<org.nr>.<invoiceId>",
 							"host": [
-								"{{TEST-URL}}invoices"
+								"{{URL}}invoices"
 							],
 							"path": [
-								"<invoiceID>"
+								"orgno-no.<org.nr>.<invoiceId>"
 							]
 						},
 						"description": "Returns a single invoice identified by its unique id. This is used to verify the state of an invoice, e.g. if it has been validated and now is available for recipients."
@@ -370,7 +370,7 @@
 							},
 							{
 								"key": "If-Match",
-								"value": "0d00436a-0000-0000-0000-5be5e8410000"
+								"value": "{{etag}}"
 							},
 							{
 								"key": "Idempotency-Key",
@@ -390,12 +390,12 @@
 							"raw": "{\n  \"due\": \"2019-03-13T15:00:00+00:00\",\n  \"amount\": 25043\n}"
 						},
 						"url": {
-							"raw": "{{TEST-URL}}invoices/<invoiceID/status/approved",
+							"raw": "{{URL}}invoices/{{invoice-id}}/status/approved",
 							"host": [
-								"{{TEST-URL}}invoices"
+								"{{URL}}invoices"
 							],
 							"path": [
-								"<invoiceID",
+								"{{invoice-id}}",
 								"status",
 								"approved"
 							]
@@ -432,7 +432,7 @@
 							},
 							{
 								"key": "If-Match",
-								"value": "1c0062d0-0000-0000-0000-5bd6ef320000"
+								"value": "{{etag}}"
 							},
 							{
 								"key": "Idempotency-Key",
@@ -452,12 +452,12 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "{{TEST-URL}}invoices/<invoiceID>/status/pending",
+							"raw": "{{TEST-URL}}invoices/{{invoice-id}}/status/pending",
 							"host": [
 								"{{TEST-URL}}invoices"
 							],
 							"path": [
-								"<invoiceID>",
+								"{{invoice-id}}",
 								"status",
 								"pending"
 							]
@@ -514,9 +514,9 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "{{TEST-URL}}invoices/{{invoice-id}}/status/deleted",
+							"raw": "{{URL}}invoices/{{invoice-id}}/status/deleted",
 							"host": [
-								"{{TEST-URL}}invoices"
+								"{{URL}}invoices"
 							],
 							"path": [
 								"{{invoice-id}}",
@@ -559,9 +559,9 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "{{TEST-URL}}invoices/{{invoice-id}}/commercial-invoice?mimeType={{mime-type}}",
+							"raw": "{{URL}}invoices/{{invoice-id}}/commercial-invoice?mimeType={{mime-type}}",
 							"host": [
-								"{{TEST-URL}}invoices"
+								"{{URL}}invoices"
 							],
 							"path": [
 								"{{invoice-id}}",
@@ -575,57 +575,6 @@
 							]
 						},
 						"description": "Returns a time-limited URL to the commercial invoice document for the given invoice. This URL typically points to a third-party invoice hotel that hosts the document. The third-party is responsible for validating the JWT."
-					},
-					"response": []
-				},
-				{
-					"name": "Get attachment for invoice",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Accept",
-								"value": "application/json",
-								"type": "text"
-							},
-							{
-								"key": "Authorization",
-								"value": "{{access-token}}",
-								"type": "text"
-							},
-							{
-								"key": "Ocp-apim-subscription-key",
-								"value": "{{subscription-key}}",
-								"type": "text"
-							},
-							{
-								"key": "vippsinvoice-recipienttoken",
-								"value": "{{recipient-token}}",
-								"type": "text"
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
-						"url": {
-							"raw": "{{TEST-URL}}invoices/{{invoice-id}}/attachments/{{attachment-id}}?mimeType={{mime-type}}",
-							"host": [
-								"{{TEST-URL}}invoices"
-							],
-							"path": [
-								"{{invoice-id}}",
-								"attachments",
-								"{{attachment-id}}"
-							],
-							"query": [
-								{
-									"key": "mimeType",
-									"value": "{{mime-type}}"
-								}
-							]
-						},
-						"description": "Returns a time-limited URL to a single attachment for an invoice. This URL typically points to a third-party invoice hotel that hosts the document. The third-party is responsible for validating the JWT."
 					},
 					"response": []
 				}
@@ -654,9 +603,9 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "{{JWK-URL}}jwk",
+							"raw": "{{TEST-URL}}jwk",
 							"host": [
-								"{{JWK-URL}}jwk"
+								"{{TEST-URL}}jwk"
 							]
 						},
 						"description": "Get JSON Web Key Set. Use a JWK library to parse this into a public key."

--- a/tools/vipps-invoice-ipp-api-postman-collection.json
+++ b/tools/vipps-invoice-ipp-api-postman-collection.json
@@ -2,7 +2,7 @@
 	"info": {
 		"_postman_id": "a2106663-0faf-4411-92f4-599c6d6aba94",
 		"name": "Vipps Invoice IPP Prod Copy",
-		"description": "This is the API for Vipps Regninger. While we have worked closely with selected partners, and believe that this is very close to production quality, we are more than happy to receive feedback, either with GitHub's issue functionality, or by email.\nPlease see https://github.com/vippsas/vipps-invoice-api for documentation",
+		"description": "This is the API for Vipps Regninger. While we have worked closely with selected partners, we are more than happy to receive feedback, either with GitHub's issue functionality, or by email.\nPlease see https://github.com/vippsas/vipps-invoice-api for documentation",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
 	"item": [

--- a/tools/vipps-invoice-isp-api-postman-collection.json
+++ b/tools/vipps-invoice-isp-api-postman-collection.json
@@ -1,8 +1,8 @@
 {
 	"info": {
-		"_postman_id": "33a5f75e-3a8d-486d-a496-c22939564ee7",
-		"name": "Vipps Invoice ISP MT",
-		"description": "This is the API for Vipps Regninger. While we have worked closely with selected partners, we are more than happy to receive feedback, either with GitHub's issue functionality, or by email.\nPlease see https://github.com/vippsas/vipps-invoice-api for documentation",
+		"_postman_id": "0308a7da-cf3d-4d48-946d-75820ef5c36f",
+		"name": "Vipps Invoice ISP Prod Copy",
+		"description": "This is the API for Vipps Regninger. While we have worked closely with selected partners, and believe that this is very close to production quality, we are more than happy to receive feedback, either with GitHub's issue functionality, or by email.\nPlease see https://github.com/vippsas/vipps-invoice-api for documentation",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
 	"item": [
@@ -52,10 +52,10 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "https://apitest.vipps.no/accesstoken/get",
+							"raw": "https://invoice-api.vipps.no/accesstoken/get",
 							"protocol": "https",
 							"host": [
-								"apitest",
+								"invoice-api",
 								"vipps",
 								"no"
 							],
@@ -110,14 +110,20 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n  \"type\": \"nin-no\",\n  \"value\": \"<nin>\"\n}"
+							"raw": "{\n  \"type\": \"nin-no\",\n  \"value\": \"\"\n}"
 						},
 						"url": {
-							"raw": "{{TEST-URL}}recipients/tokens",
+							"raw": "https://invoice-api.vipps.no/vipps-isp/v1/recipients/tokens",
+							"protocol": "https",
 							"host": [
-								"{{TEST-URL}}recipients"
+								"invoice-api",
+								"vipps",
+								"no"
 							],
 							"path": [
+								"vipps-isp",
+								"v1",
+								"recipients",
 								"tokens"
 							]
 						},
@@ -157,18 +163,29 @@
 							{
 								"key": "Ocp-apim-subscription-key",
 								"value": "{{subscription-key}}"
+							},
+							{
+								"key": "fdsfsd",
+								"value": "fdsfdsf",
+								"type": "text"
 							}
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n  \"type\": \"msisdn\",\n  \"value\": \"<msisdn>\"\n}"
+							"raw": "{\n  \"type\": \"msisdn\",\n  \"value\": \"\"\n}"
 						},
 						"url": {
-							"raw": "{{TEST-URL}}recipients/tokens",
+							"raw": "https://invoice-api.vipps.no/vipps-isp/v1/recipients/tokens",
+							"protocol": "https",
 							"host": [
-								"{{TEST-URL}}recipients"
+								"invoice-api",
+								"vipps",
+								"no"
 							],
 							"path": [
+								"vipps-isp",
+								"v1",
+								"recipients",
 								"tokens"
 							]
 						},
@@ -211,15 +228,21 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n  \"recipientToken\": \"{{recipient-token}}\",\n  \"paymentInformation\": {\n    \"type\": \"kid\",\n    \"value\": \"<value>\",\n    \"account\": \"<account>\"\n  },\n  \"invoiceType\": \"invoice\",\n  \"due\": \"2019-03-13T15:00:00+00:00\",\n  \"amount\": <amount>,\n  \"minAmount\": <amount>,\n  \"subject\": \"issuerName\",\n  \"issuerName\": \"issuerName\",\n  \"commercialInvoice\": [\n    {\n      \"mimeType\": \"application/pdf\",\n      \"url\": \"https://www.example.com/08fd5360-e218-4658-894f-4f37649e7df7/comminv.pdf\"\n    }\n  ],\n  \"attachments\": [\n    {\n      \"title\": \"Ferry\",\n      \"urls\": [\n        {\n          \"url\": \"https://invoice-hotel.example.org/invoice/42.pdf\",\n          \"mimeType\": \"application/pdf\"\n        }\n      ]\n    }\n  ],\n  \"issuerIconUrl\": \"https://www.example.com/logos/lister.png\"\n}"
+							"raw": "{\n  \"recipientToken\": \"{{recipient-token}}\",\n  \"paymentInformation\": {\n    \"type\": \"kid\",\n    \"value\": \"<kid>\",\n    \"account\": \"<bank account>\"\n  },\n  \"invoiceType\": \"invoice\",\n  \"due\": \"2019-07-10T15:00:00+00:00\",\n  \"amount\": 200,\n  \"minAmount\": 200,\n  \"subject\": \"subject\",\n  \"issuerName\": \"subject\",\n  \"commercialInvoice\": [\n    {\n      \"mimeType\": \"application/pdf\",\n      \"url\": \"https://www.example.com/08fd5360-e218-4658-894f-4f37649e7df7/comminv.pdf\"\n    }\n  ],\n  \"issuerIconUrl\": \"https://www.example.com/logos/lister.png\"\n}"
 						},
 						"url": {
-							"raw": "{{TEST-URL}}invoices/orgno-no.918130047.256203249",
+							"raw": "https://api.vipps.no/vipps-isp/v1/invoices/orgno-no.<org.nr>.<invoiceId>",
+							"protocol": "https",
 							"host": [
-								"{{TEST-URL}}invoices"
+								"api",
+								"vipps",
+								"no"
 							],
 							"path": [
-								"orgno-no.918130047.256203249"
+								"vipps-isp",
+								"v1",
+								"invoices",
+								"orgno-no.<org.nr>.<invoiceId>"
 							]
 						},
 						"description": "This endpoint adds the provided invoice to our system. To submit invoices into our system this endpoint has to be used.\nWe will accept any invoice as long as the body is well formed JSON. Any validation errors of the invoice are picked up by workers in the background and available with `GET:/invoices/{invoiceId}`.\n## Idempotency\nThe endpoint is idempotent. If an invoice with the same unique identifiers (organisation number and invoice reference) is submitted and the invoice exists already in the system, it is rejected. Invoices cannot be changed."
@@ -272,12 +295,12 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "{{TEST-URL}}invoices/orgno-no.918130047.256203222",
+							"raw": "{{TEST-URL}}invoices/orgno-no.993417262.256243244356",
 							"host": [
 								"{{TEST-URL}}invoices"
 							],
 							"path": [
-								"orgno-no.918130047.256203222"
+								"orgno-no.993417262.256243244356"
 							]
 						},
 						"description": "Returns a single invoice identified by its unique id. This is used to verify the state of an invoice, e.g. if it has been validated and now is available for recipients."
@@ -328,12 +351,12 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "{{TEST-URL}}invoices/orgno-no.918130047.256203878/status/revoked",
+							"raw": "{{TEST-URL}}invoices/orgno-no.993417262.25624324535/status/revoked",
 							"host": [
 								"{{TEST-URL}}invoices"
 							],
 							"path": [
-								"orgno-no.918130047.256203878",
+								"orgno-no.993417262.25624324535",
 								"status",
 								"revoked"
 							]
@@ -367,9 +390,9 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "{{JWK-URL}}jwk",
+							"raw": "{{TEST-URL}}jwk",
 							"host": [
-								"{{JWK-URL}}jwk"
+								"{{TEST-URL}}jwk"
 							]
 						},
 						"description": "Get JSON Web Key Set. Use a JWK library to parse this into a public key."

--- a/tools/vipps-invoice-isp-api-postman-collection.json
+++ b/tools/vipps-invoice-isp-api-postman-collection.json
@@ -2,7 +2,7 @@
 	"info": {
 		"_postman_id": "0308a7da-cf3d-4d48-946d-75820ef5c36f",
 		"name": "Vipps Invoice ISP Prod Copy",
-		"description": "This is the API for Vipps Regninger. While we have worked closely with selected partners, and believe that this is very close to production quality, we are more than happy to receive feedback, either with GitHub's issue functionality, or by email.\nPlease see https://github.com/vippsas/vipps-invoice-api for documentation",
+		"description": "This is the API for Vipps Regninger. While we have worked closely with selected partners, we are more than happy to receive feedback, either with GitHub's issue functionality, or by email.\nPlease see https://github.com/vippsas/vipps-invoice-api for documentation",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
 	"item": [

--- a/vipps-invoice-api.md
+++ b/vipps-invoice-api.md
@@ -56,7 +56,7 @@ Document version: 0.3.11.
     - [Get recipient token](#get-recipient-token)
     - [Get invoices](#get-invoices)
   - [National identity number (NIN), or phone number (MSISDN), not available](#national-identity-number-nin-or-phone-number-msisdn-not-available)
-- [Retrieving invoice documents (attachments)](#retrieving-invoice-documents-attachments)
+- [Retrieving commercial-invoice document](#retrieving-commercial-invoice-document)
   - [Typical flow](#typical-flow)
   - [Validating the JSON Web Token (JWT) and the request](#validating-the-json-web-token-jwt-and-the-request)
   - [The API's public key: JWK (JSON Web Key)](#the-apis-public-key-jwk-json-web-key)
@@ -346,8 +346,7 @@ These variables will be set when the `Get Single Invoice` call is made.
 These calls require `{{invoice-id}}` and `{{mime-type}}`.
 These variables will be set when the `Get Single Invoice` call is made.
 
-1. [`Get commercial invoice document`](https://vippsas.github.io/vipps-invoice-api/ipp.html#/IPP/Get_Commercial_Invoice_Document_v1)
-2. [`Get attachment for invoice`](https://vippsas.github.io/vipps-invoice-api/ipp.html#/IPP/Get_Attachment_For_Invoice_v1)
+- [`Get commercial invoice document`](https://vippsas.github.io/vipps-invoice-api/ipp.html#/IPP/Get_Commercial_Invoice_Document_v1)
 
 
 # InvoiceId and variables
@@ -385,8 +384,7 @@ Following is an overview of the different variables in the Postman environments.
 | idempotency-key  | Pre-request Script                             | When all `PUT` calls are sent            | No            |
 | TEST-URL         | Default in Environment                         | Default                                  | No            |
 | invoice-id       | Postman Tests                                  | When 'Get single invoice' is sent        | Yes           |
-| mime-type        | Postman Tests                                  | When 'Get single invoice' is sent        | Yes           |
-| attachment-id    | Postman Tests                                  | When 'Get single invoice' is sent        | Yes           |
+| mime-type        | Postman Tests                                  | When 'Get commercial invoice document' is sent        | Yes           |
 
 
 # Authentication and authorization
@@ -560,15 +558,6 @@ vippsinvoice-recipienttoken : ***
       "mimeType": "application/pdf"
     }
   ],
-  "attachments": [
-    {
-      "id": "1",
-      "title": "Ferry",
-      "mimeTypes": [
-        "application/pdf"
-      ]
-    }
-  ],
   "issuerIconUrl": "https://www.example.com/logos/lister.png",
   "status": {
     "created": "2018-08-30T09:11:19Z",
@@ -588,10 +577,7 @@ vippsinvoice-recipienttoken : ***
 Vipps requires either NIN or MSISDN for
 [`POST:/recipients/tokens`](https://vippsas.github.io/vipps-invoice-api/isp.html#/ISP/Request_Recipient_Token_v1).
 
-# Retrieving invoice documents (attachments)
-
-Invoice documents may be additional invoice documentation, such as
-commercial invoices and attachments.
+# Retrieving commercial-invoice document
 
 The IPP should retrieve the _actual_ document download URL on-demand on
 behalf of its user. This is typically initiated when the user clicks on a
@@ -603,10 +589,9 @@ The URL contains a JWT query parameter that is validated by the ISP.
 The expiry time (`EXP`) is inside the JWT.
 
 Each invoice document has one or more MIME types. This means that
-[`GET:/invoices/{invoiceId}/attachments/{attachmentId}`](https://vippsas.github.io/vipps-invoice-api/ipp.html#/IPP/Get_Attachment_For_Invoice_v1)
+[`GET:/invoices/{invoiceId}/commercial-invoice`](https://vippsas.github.io/vipps-invoice-api/ipp.html#/IPP/Get_Commercial_Invoice_Document_v1)
 must include the `mimeType` query parameter that specifies the mime type to
-retrieve, i.e. document file type. The MIME type is available to the IPP when
-listing all the documents. This allows the IPP to present it in multiple ways.
+retrieve, i.e. document file type. This allows the IPP to present it in multiple ways.
 
 PDF is a commonly used MIME type, which can be displayed in most contexts.
 
@@ -929,17 +914,6 @@ This is an example of the payload for `PUT:/invoices/{invoiceId}/orgno-no.947571
     {
       "mimeType": "application/pdf",
       "url": "https://www.example.com/abc123/comminv.pdf"
-    }
-  ],
-  "attachments": [
-    {
-      "title": "100 pairs of socks",
-      "urls": [
-        {
-          "url": "https://invoice-hotel.example.org/invoice/abc123.pdf",
-          "mimeType": "application/pdf"
-        }
-      ]
     }
   ],
   "issuerIconUrl": "https://www.example.com/logos/vipps-socks-store-logo.png"


### PR DESCRIPTION
- Swagger: Removed parts describing attachments. Wrote "Depricated" on "Get attachment for invoice" request.
- Invoice api documentation: Removed parts describing attachments, and edited the section "Retrieving invoice documents (attachments)"
- Postman: Removed attachments from body for ISP and removed the "Get attachment for invoice" request. 

Is it necessary to say (in the documentation) that attachments still will be supported in backend, but not visible in the app? 
Or should I just communicate this to integrators that already have started the integration? 

