### PR TITLE
describe approved -> pending limitations

### DIFF
--- a/vipps-invoice-api.md
+++ b/vipps-invoice-api.md
@@ -852,7 +852,11 @@ again with the updated payment details.
 **Transition 9: `approved` -> `pending`**
 
 The user may want to change an `approved` invoice back to `pending`.
-_This transition is not yet fully specified._
+This transition *can only be done by the same IPP who approved the invoice*.
+This limitation is required to make sure that the IPP who originally set the
+invoice to approved does not accidentally pay the invoice. There is no way
+the approving IPP can get notified if another IPP would set the state back to
+pending.
 
 **Transition 10: `approved` -> `deleted`**
 


### PR DESCRIPTION
explain the limitations for setting an invoice from approved back to pending after questions from an integrator.

@simenarvnes @cloveras just merge if you approve