### PR TITLE
IPP: Add bankCode to set status endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ install it using `pip`.
 
 # Swagger changelog
 
+## 0.3.40
+
+* IPP: Add optional details about bankCode in set status to delete or pending
+
 ## 0.3.39
 * Add field `scope` to `invoiceOut` model. The value is either `vipps` or `nets`
   and indicates if the invoice was originally sent as Vipps Regning or eFaktura.

--- a/docs/swagger-ipp.json
+++ b/docs/swagger-ipp.json
@@ -1250,7 +1250,7 @@
         "bankCode": {
           "type": "string",
           "pattern": "^\\d{4}$",
-          "description": "Bank code of the bank account originally used to pay the invoice (bankregistreringsnummer)",
+          "description": "Bank code (bankregistreringsnummer) of the bank changing the state of the invoice. If the invoice is in state approved, the bank changing the status have to be the same bank that approved originally.",
           "example": 3305
         }
       }

--- a/docs/swagger-ipp.json
+++ b/docs/swagger-ipp.json
@@ -2,7 +2,7 @@
   "swagger": "2.0",
   "info": {
     "title": "Vipps Invoice IPP API",
-    "version": "0.3.39",
+    "version": "0.3.40",
     "description": "This is the API for Vipps eFaktura. While we have worked closely with selected partners, we are more than happy to receive feedback, either with GitHub's issue functionality, or by email.\nPlease see https://github.com/vippsas/vipps-invoice-api for documentation"
   },
   "host": "apitest.vipps.no",
@@ -449,6 +449,13 @@
             "enum": [
               "bearer <access_token>"
             ]
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "$ref": "#/definitions/StatusChangeDetails"
+            }
           }
         ],
         "responses": {
@@ -525,6 +532,13 @@
             "enum": [
               "bearer <access_token>"
             ]
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "$ref": "#/definitions/StatusChangeDetails"
+            }
           }
         ],
         "responses": {
@@ -1229,6 +1243,17 @@
         "due",
         "amount"
       ]
+    },
+    "StatusChangeDetails": {
+      "type": "object",
+      "properties": {
+        "bankCode": {
+          "type": "string",
+          "pattern": "^\\d{4}$",
+          "description": "Bank code of the bank account originally used to pay the invoice (bankregistreringsnummer)",
+          "example": 3305
+        }
+      }
     },
     "MsError": {
       "type": "object",

--- a/docs/swagger-ipp.yaml
+++ b/docs/swagger-ipp.yaml
@@ -907,7 +907,7 @@ definitions:
       bankCode:
         type: string
         pattern: "^\\d{4}$"
-        description: Bank code of the bank account originally used to pay the invoice (bankregistreringsnummer)
+        description: Bank code (bankregistreringsnummer) of the bank changing the state of the invoice. If the invoice is in state approved, the bank changing the status have to be the same bank that approved originally.
         example: 3305
   MsError:
     type: object

--- a/docs/swagger-ipp.yaml
+++ b/docs/swagger-ipp.yaml
@@ -1,7 +1,7 @@
 swagger: '2.0'
 info:
   title: Vipps Invoice IPP API
-  version: '0.3.39'
+  version: '0.3.40'
   description: >-
     This is the API for Vipps eFaktura. While we have worked closely with
     selected partners, we are more than happy to receive feedback, either with GitHub's
@@ -331,6 +331,10 @@ paths:
           type: string
           enum:
             - bearer <access_token>
+        - name: body
+          in: body
+          schema:
+            $ref: '#/definitions/StatusChangeDetails'
       responses:
         '204':
           description: OK (no content)
@@ -388,6 +392,10 @@ paths:
           type: string
           enum:
             - bearer <access_token>
+        - name: body
+          in: body
+          schema:
+            $ref: '#/definitions/StatusChangeDetails'
       responses:
         '204':
           description: OK (no content)
@@ -893,6 +901,14 @@ definitions:
     required:
       - due
       - amount
+  StatusChangeDetails:
+    type: object
+    properties:
+      bankCode:
+        type: string
+        pattern: "^\\d{4}$"
+        description: Bank code of the bank account originally used to pay the invoice (bankregistreringsnummer)
+        example: 3305
   MsError:
     type: object
     properties:

--- a/docs/swagger-isp.json
+++ b/docs/swagger-isp.json
@@ -2,7 +2,7 @@
   "swagger": "2.0",
   "info": {
     "title": "Vipps Invoice ISP API",
-    "version": "0.3.39",
+    "version": "0.3.40",
     "description": "\nThis is the API for Vipps eFaktura. While we have worked closely with selected partners, we are more than happy to receive feedback, either with GitHub's issue functionality, or by email.\nPlease see https://github.com/vippsas/vipps-invoice-api for documentation"
   },
   "host": "apitest.vipps.no",

--- a/docs/swagger-isp.yaml
+++ b/docs/swagger-isp.yaml
@@ -1,7 +1,7 @@
 swagger: '2.0'
 info:
   title: Vipps Invoice ISP API
-  version: '0.3.39'
+  version: '0.3.40'
   description: >-
 
     This is the API for Vipps eFaktura. While we have worked closely with


### PR DESCRIPTION
After integrating with Nets eFaktura, the logic for validating which actor are changing the status has changed. Vipps Regninger check to see if the IPP-actor changing the status after approved is the same as originally approved the invoice. With Nets, this is done using bankCode. So if the IPP has approved an invoice supplying a specific bankCode, it has to send the same bankCode in subsequent set status to pending or deleted calls in order to get through the validation.