### PR TITLE
ISP - Validation of due: Must be minimum 3 days in the future

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ install it using `pip`.
 
 # Swagger changelog
 
+## 0.3.41
+
+* ISP - Validation of due: Must be minimum 3 days in the future
+
 ## 0.3.40
 
 * IPP: Add optional details about bankCode in set status to delete or pending

--- a/docs/swagger-ipp.json
+++ b/docs/swagger-ipp.json
@@ -2,7 +2,7 @@
   "swagger": "2.0",
   "info": {
     "title": "Vipps Invoice IPP API",
-    "version": "0.3.40",
+    "version": "0.3.41",
     "description": "This is the API for Vipps eFaktura. While we have worked closely with selected partners, we are more than happy to receive feedback, either with GitHub's issue functionality, or by email.\nPlease see https://github.com/vippsas/vipps-invoice-api for documentation"
   },
   "host": "apitest.vipps.no",

--- a/docs/swagger-ipp.yaml
+++ b/docs/swagger-ipp.yaml
@@ -1,7 +1,7 @@
 swagger: '2.0'
 info:
   title: Vipps Invoice IPP API
-  version: '0.3.40'
+  version: '0.3.41'
   description: >-
     This is the API for Vipps eFaktura. While we have worked closely with
     selected partners, we are more than happy to receive feedback, either with GitHub's

--- a/docs/swagger-isp.json
+++ b/docs/swagger-isp.json
@@ -2,7 +2,7 @@
   "swagger": "2.0",
   "info": {
     "title": "Vipps Invoice ISP API",
-    "version": "0.3.40",
+    "version": "0.3.41",
     "description": "\nThis is the API for Vipps eFaktura. While we have worked closely with selected partners, we are more than happy to receive feedback, either with GitHub's issue functionality, or by email.\nPlease see https://github.com/vippsas/vipps-invoice-api for documentation"
   },
   "host": "apitest.vipps.no",
@@ -468,7 +468,7 @@
         "due": {
           "type": "string",
           "format": "date-time",
-          "description": "When an invoice is due. Due has to be formatted according to RFC3339 and be at least the current day at start of day and at most 1 year in the future.",
+          "description": "When an invoice is due. Due has to be formatted according to RFC3339 and be at least 3 days after start of day and at most 1 year in the future.",
           "example": "2019-10-02T15:00:00Z"
         },
         "amount": {

--- a/docs/swagger-isp.yaml
+++ b/docs/swagger-isp.yaml
@@ -1,7 +1,7 @@
 swagger: '2.0'
 info:
   title: Vipps Invoice ISP API
-  version: '0.3.40'
+  version: '0.3.41'
   description: >-
 
     This is the API for Vipps eFaktura. While we have worked closely with
@@ -366,7 +366,7 @@ definitions:
       due:
         type: string
         format: date-time
-        description: When an invoice is due. Due has to be formatted according to RFC3339 and be at least the current day at start of day and at most 1 year in the future.
+        description: When an invoice is due. Due has to be formatted according to RFC3339 and be at least 3 days after start of day and at most 1 year in the future.
         example: '2019-10-02T15:00:00Z'
       amount:
         type: integer


### PR DESCRIPTION
Our partner require **due** to be at least _3 days_ in the future and Vipps Regninger API must have matching validation logic as our partner.